### PR TITLE
Refactor processing logic into services

### DIFF
--- a/api/services/processing.py
+++ b/api/services/processing.py
@@ -1,0 +1,119 @@
+import os
+from typing import List, Dict, Any
+
+from django.conf import settings
+from PIL import Image
+import torch
+import clip
+from langchain_ollama import OllamaEmbeddings
+
+from ..pdf_embeddings import embed_pdf_and_store
+from ..embeddings_to_neo import (
+    limpiar_meta,
+    store_embedding,
+    guardar_imagen_en_weaviate,
+)
+from ..weaviate_client import CLIENT
+
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+try:
+    MODEL_CLIP, PREPROCESS = clip.load("ViT-B/32", device=DEVICE)
+except Exception:  # pragma: no cover - handled during runtime
+    MODEL_CLIP, PREPROCESS = None, None
+
+
+def process_pdf(file_id: str, meta: Dict[str, Any]) -> None:
+    pdf_path = os.path.join("uploads", meta["file_location"])
+    embeddings_created, uuids = embed_pdf_and_store(
+        pdf_path=pdf_path, original_doc_id=file_id, client=CLIENT
+    )
+    store_embedding(doc_id=file_id, embedding=[], label="UnconnectedDoc", meta=meta)
+
+
+def _encode_image(image_path: str) -> List[float]:
+    if not MODEL_CLIP or not PREPROCESS:
+        raise RuntimeError("CLIP model not available")
+    image = Image.open(image_path).convert("RGB")
+    image_input = PREPROCESS(image).unsqueeze(0).to(DEVICE)
+    with torch.no_grad():
+        image_features = MODEL_CLIP.encode_image(image_input)
+    image_features /= image_features.norm(dim=-1, keepdim=True)
+    return image_features.cpu().numpy()[0].tolist()
+
+
+def process_image_with_description(file_id: str, meta: Dict[str, Any], image_path: str) -> None:
+    embedding_clip = _encode_image(image_path)
+    texts_for_embedding: List[str] = []
+    if meta.get("style"):
+        texts_for_embedding.append(meta["style"])
+    if meta.get("composition"):
+        texts_for_embedding.append(meta["composition"])
+    if meta.get("analysis"):
+        texts_for_embedding.append(meta["analysis"])
+    if meta.get("description"):
+        texts_for_embedding.append(meta["description"])
+    embedding_des = []
+    if texts_for_embedding:
+        embedding_model = OllamaEmbeddings(
+            model=settings.DEFAULT_EMBED_MODEL, base_url=settings.LLM_BASE_URL
+        )
+        embedding_des = embedding_model.embed_documents([" ".join(texts_for_embedding)])[0]
+
+    propiedades = limpiar_meta(meta)
+    guardar_imagen_en_weaviate(
+        client=CLIENT,
+        meta=propiedades,
+        vec_clip=embedding_clip,
+        vec_desc=embedding_des,
+    )
+    store_embedding(doc_id=file_id, embedding=[], label="UnconnectedDoc", meta=meta)
+
+
+def process_ocr_with_image(file_id: str, meta: Dict[str, Any], image_path: str) -> None:
+    ocr_text = meta.get("ocr_text", "")
+    if not ocr_text:
+        raise ValueError("No se encontró 'ocr_text' para procesamiento OCR")
+    meta["content"] = ocr_text
+    embedding_model = OllamaEmbeddings(
+        model=settings.DEFAULT_EMBED_MODEL, base_url=settings.LLM_BASE_URL
+    )
+    embedding_text = embedding_model.embed_documents([ocr_text])[0]
+
+    embedding_clip = _encode_image(image_path)
+    propiedades = limpiar_meta(meta)
+    guardar_imagen_en_weaviate(
+        client=CLIENT,
+        meta=propiedades,
+        vec_clip=embedding_clip,
+        vec_ocr=embedding_text,
+    )
+    store_embedding(doc_id=file_id, embedding=[], label="UnconnectedDoc", meta=meta)
+
+
+def process_text_embeddings(meta: Dict[str, Any]) -> List[float]:
+    texts_for_embedding: List[str] = []
+    if meta.get("ocr_text"):
+        texts_for_embedding.append(meta["ocr_text"])
+    if meta.get("multilingual"):
+        for lang_code in meta.get("languages", []):
+            key = f"content_{lang_code}"
+            if key in meta and meta[key]:
+                texts_for_embedding.append(meta[key])
+    else:
+        if meta.get("content"):
+            texts_for_embedding.append(meta["content"])
+        if meta.get("analysis"):
+            texts_for_embedding.append(meta["analysis"])
+        if meta.get("description"):
+            texts_for_embedding.append(meta["description"])
+
+    combined_text = " ".join(texts_for_embedding)
+    if not combined_text:
+        return []
+
+    embedding_model = OllamaEmbeddings(
+        model=settings.DEFAULT_EMBED_MODEL, base_url=settings.LLM_BASE_URL
+    )
+    return embedding_model.embed_documents([combined_text])[0]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,46 @@
+import os
+from unittest import mock
+
+import pytest
+
+from api.services import processing
+
+
+def test_process_pdf_calls_dependencies(tmp_path):
+    meta = {"file_location": "docs/sample.pdf"}
+    with mock.patch.object(processing, "embed_pdf_and_store") as m_embed, \
+         mock.patch.object(processing, "store_embedding") as m_store:
+        m_embed.return_value = (1, ["uuid"])
+        processing.process_pdf("file1", meta)
+        m_embed.assert_called_once_with(
+            pdf_path=os.path.join("uploads", "docs/sample.pdf"),
+            original_doc_id="file1",
+            client=processing.CLIENT,
+        )
+        m_store.assert_called_once()
+
+
+def test_process_image_with_description_calls_services(tmp_path):
+    meta = {"file_location": "img.jpg", "style": "s"}
+    with mock.patch.object(processing, "_encode_image", return_value=[0.1]), \
+         mock.patch.object(processing, "OllamaEmbeddings") as m_emb, \
+         mock.patch.object(processing, "guardar_imagen_en_weaviate") as m_save, \
+         mock.patch.object(processing, "store_embedding") as m_store:
+        m_emb.return_value.embed_documents.return_value = [[0.2]]
+        processing.process_image_with_description("fid", meta, "path")
+        m_save.assert_called_once()
+        m_store.assert_called_once()
+
+
+def test_process_ocr_with_image_without_text():
+    with pytest.raises(ValueError):
+        processing.process_ocr_with_image("fid", {}, "img")
+
+
+def test_process_text_embeddings_returns_vector():
+    meta = {"content": "hola"}
+    with mock.patch.object(processing, "OllamaEmbeddings") as m_emb:
+        m_emb.return_value.embed_documents.return_value = [[0.3]]
+        vec = processing.process_text_embeddings(meta)
+        assert vec == [0.3]
+        m_emb.assert_called_once()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,23 @@
+from unittest import mock
+from django.test import Client
+from django.urls import reverse
+
+from api.models import UploadedFile
+
+
+def test_metadata_processing_view_delegates(db):
+    UploadedFile.objects.create(
+        original_name="sample.txt",
+        file="/tmp/sample.txt",
+        file_type="text/plain",
+        status="pending",
+        file_location="texts/sample.txt",
+    )
+
+    data = [{"original_name": "sample.txt", "embedding_type": "pdf", "file_location": "texts/sample.txt"}]
+    client = Client()
+    with mock.patch("api.services.processing.process_pdf") as m_pdf:
+        m_pdf.return_value = None
+        response = client.post(reverse("metadata_process"), data, content_type="application/json")
+        assert response.status_code == 200
+        m_pdf.assert_called_once()


### PR DESCRIPTION
## Summary
- move processing logic to `api/services/processing.py`
- delegate `MetadataProcessingView.post` to new service functions
- add unit tests for service functions
- add integration test for MetadataProcessingView

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6867610be4908322abe2bcb5e50ef038