### PR TITLE
Add multimodal search for audio and video

### DIFF
--- a/api/rag_views.py
+++ b/api/rag_views.py
@@ -8,10 +8,17 @@ from rest_framework.parsers import MultiPartParser, JSONParser, FormParser
 from rest_framework.response import Response
 from rest_framework import status
 import weaviate.classes as wvc
-from .weaviate_client import CLIENT 
+from .weaviate_client import CLIENT
 from .resources import (
-    CLIP_EMB, TEXT_EMB, CLASSES, IMAGE_VECTOR_FIELDS, short_query
+    CLIP_EMB,
+    TEXT_EMB,
+    CLASSES,
+    IMAGE_VECTOR_FIELDS,
+    AUDIO_VECTOR_FIELDS,
+    VIDEO_VECTOR_FIELDS,
+    short_query,
 )
+from .services.processing import _encode_audio, _encode_video
 
 def run_wv_query(
     cls: str,
@@ -58,11 +65,15 @@ class MultiModalSearchView(APIView):
             "text": data.get("search_text") in ("true", True, "1"),
             "pdf": data.get("search_pdf") in ("true", True, "1"),
             "image": data.get("search_image") in ("true", True, "1"),
+            "audio": data.get("search_audio") in ("true", True, "1"),
+            "video": data.get("search_video") in ("true", True, "1"),
         }
         ks = {
             "text": int(data.get("k_text", 5)),
             "pdf": int(data.get("k_pdf", 20)),
             "image": int(data.get("k_image", 10)),
+            "audio": int(data.get("k_audio", 5)),
+            "video": int(data.get("k_video", 5)),
         }
         if not any(flags.values()):
             return Response(
@@ -72,8 +83,8 @@ class MultiModalSearchView(APIView):
 
         results = defaultdict(list)
 
-        # ── TEXT / PDF ─────────────────────────────────────
-        if flags["text"] or flags["pdf"]:
+        # ── TEXT / PDF / AUDIO / VIDEO -----------------------------
+        if any(flags[x] for x in ("text", "pdf", "audio", "video")):
             vec_txt = TEXT_EMB.embed_query(short_query(query_txt))
             if flags["text"]:
                 results["text_results"] = run_wv_query(
@@ -84,7 +95,15 @@ class MultiModalSearchView(APIView):
                     CLASSES["pdf"],
                     vec_txt,
                     ks["pdf"],
-                    props=("original_doc_id", "page_number", "chunk_sequence",   "text_chunk", ),
+                    props=("original_doc_id", "page_number", "chunk_sequence", "text_chunk", ),
+                )
+            if flags["audio"]:
+                results["audio_text"] = run_wv_query(
+                    CLASSES["audio"], vec_txt, ks["audio"], AUDIO_VECTOR_FIELDS["text"]
+                )
+            if flags["video"]:
+                results["video_text"] = run_wv_query(
+                    CLASSES["video"], vec_txt, ks["video"], VIDEO_VECTOR_FIELDS["text"]
                 )
 
         # ── IMAGES ─────────────────────────────────────────
@@ -115,5 +134,25 @@ class MultiModalSearchView(APIView):
                     results["image_description"] = run_wv_query(
                         CLASSES["image"], vec, ks["image"], IMAGE_VECTOR_FIELDS["des"]
                     )
+
+        # ── AUDIO ──────────────────────────────────────────
+        if flags["audio"]:
+            if "audio_file" in request.FILES:
+                f = request.FILES["audio_file"]
+                path = f.temporary_file_path() if hasattr(f, "temporary_file_path") else f.name
+                vec = _encode_audio(path)
+                results["audio_audio"] = run_wv_query(
+                    CLASSES["audio"], vec, ks["audio"], AUDIO_VECTOR_FIELDS["audio"]
+                )
+
+        # ── VIDEO ──────────────────────────────────────────
+        if flags["video"]:
+            if "video_file" in request.FILES:
+                f = request.FILES["video_file"]
+                path = f.temporary_file_path() if hasattr(f, "temporary_file_path") else f.name
+                vec = _encode_video(path)
+                results["video_video"] = run_wv_query(
+                    CLASSES["video"], vec, ks["video"], VIDEO_VECTOR_FIELDS["video"]
+                )
 
         return Response({"query_used": query_txt, **results})

--- a/api/resources.py
+++ b/api/resources.py
@@ -74,5 +74,24 @@ def short_query(q: str) -> str:
         rewritten = q
     return safe_for_clip(rewritten)
 
-CLASSES = dict(text="Textos", pdf="PdfChunks", image="Imagenes")
-IMAGE_VECTOR_FIELDS = dict(clip="vector_clip", ocr="vector_ocr", des="vector_des")
+CLASSES = dict(
+    text="Textos",
+    pdf="PdfChunks",
+    image="Imagenes",
+    audio="Audio",
+    video="Video",
+)
+
+IMAGE_VECTOR_FIELDS = dict(
+    clip="vector_clip",
+    ocr="vector_ocr",
+    des="vector_des",
+)
+
+# Nombres de los vectores para audio y video
+AUDIO_VECTOR_FIELDS = dict(audio="vector_audio", text="vector_text")
+VIDEO_VECTOR_FIELDS = dict(
+    video="vector_video",
+    audio="vector_audio",
+    text="vector_text",
+)


### PR DESCRIPTION
## Summary
- extend resource mappings for audio and video search
- support searching audio and video via text or file input
- expose audio/video vector field names

## Testing
- `python -m py_compile api/rag_views.py api/resources.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6889950273fc8322af355ab916cf28ad